### PR TITLE
change HTTP verb from put to post in api doc to submit a student grade

### DIFF
--- a/src/routes/SgbRouter.ts
+++ b/src/routes/SgbRouter.ts
@@ -276,7 +276,7 @@ public studentCourses(req: Request, res: Response, next: NextFunction) {
 	 this.router.get('/student/note', this.studentNote.bind(this)); // pour .bind voir https://stackoverflow.com/a/15605064/1168342
 		
 	 /**
-	 * @api {put} /v1/note?student_id=student_id&course_id=course_id&type=type&type_id=type_id&note=note Enseignant ajouter une note à un étudiant
+	 * @api {post} /v1/note?student_id=student_id&course_id=course_id&type=type&type_id=type_id&note=note Enseignant ajouter une note à un étudiant
 	 * @apiGroup Enseignant
 	 * @apiDescription L'enseignant ajoute une note dans le dossier de l'étudiant
 	 * @apiVersion 1.0.0


### PR DESCRIPTION
# Quoi de neuf ?
- Correction d'un bug où le mauvais verbe HTTP était affiché dans la documentation d'API pour la route permettant de soumettre la note d'un étudiant pour un devoir ou un questionnaire

# Comment tester?
- builder puis lancer le sgb. S'assurer que la route POST api/v1/note n'est pas indiqué comme étant une route PUT dans la doc d'api