### PR TITLE
Corriger documentation /api/v1/note

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
     "target": "es6",
     "module": "commonjs",
     "outDir": "dist",
-    "types": [ "node" ],
-    "typeRoots": [ "../node_modules/@types" ]
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
La documentation d'API pour /api/v1/note indique qu'il s'agit d'un PUT alors qu'il s'agit plutôt d'un POST.