### PR TITLE
Support pour Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.dockerignore
+Dockerfile
+docker-compose.yml
+
+.git
+.gitignore
+
+node_modules
+.env
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN npm install
 COPY . .
 
 RUN npm run compile
-CMD [ "npm", "start" ]
+CMD [ "npm", "start-docker" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN npm install
 COPY . .
 
 RUN npm run compile
-CMD [ "npm", "start-docker" ]
+CMD [ "npm", "run", "start-docker" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:16.6.2
+
+WORKDIR /app
+
+COPY ["package.json", "package-lock.json*", "./"]
+
+RUN npm install -g node-gyp
+RUN npm install
+
+COPY . .
+
+RUN npm run compile
+CMD [ "npm", "start" ]

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "start2": "apidoc -i src/routes/ -o dist/docs/ & node dist/index.js & open http://localhost:3200",
         "start": "apidoc -i src/routes/ -o dist/docs/ & node dist/index.js & open http://127.0.0.1:3200",
+        "start-docker": "apidoc -i src/routes/ -o dist/docs/ & node dist/index.js",
         "test": "jest --coverage",
         "watch": "jest --coverage --watchAll",
         "docs": "apidoc -i src/routes/ -o dist/docs/",


### PR DESCRIPTION
J'ai ajouté ces quelques fichiers pour supporter Docker. Je trouve cela utile pour déployer rapidement l'API sur mon serveur qui peut ensuite être utilisé facilement par tout membre d'une équipe sans avoir à démarrer ce projet à chaquer démarrage du laboratoire.

Ce n'est pas nécessaire au bon fonctionnement du projet, mais c'est un "nice-to-have".